### PR TITLE
Use `cursor.connection` instead of `cursor.cursor` for psycopg2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.2.2 (2025-01-02)
+
+#### Changes
+
+  - Use `cursor.connection` in psycopg2 to avoid issues caused by agents like NewRelic that wrap cursor objects by [@wesleykendall](https://github.com/wesleykendall) in [#51](https://github.com/AmbitionEng/django-pgbulk/pull/51).
+
 ## 3.2.1 (2024-12-15)
 
 #### Changes

--- a/pgbulk/core.py
+++ b/pgbulk/core.py
@@ -149,7 +149,7 @@ class UpsertResult(List["Row"]):
 def _quote(field: str, cursor: "CursorWrapper") -> str:
     """Quote identifiers."""
     if psycopg_maj_version == 2:
-        return quote_ident(field, cursor.cursor)  # type: ignore
+        return quote_ident(field, cursor.connection)  # type: ignore
     else:
         return (
             Escaping(cursor.connection.pgconn)  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "3.2.1"
+version = "3.2.2"
 description = "Native Postgres update, upsert, and copy operations."
 authors = ["Wes Kendall"]
 classifiers = [


### PR DESCRIPTION
Agents such as new relic seem to improperly patch out the underlying cursor object, causing failures for psycopg2's `quote_ident` - Use the connection object instead, which is also a valid argument to this function and seems to be patched properly by performance monitoring agents